### PR TITLE
feat: Add makefile target for deps, add licensei

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,6 +101,46 @@ jobs:
         run: docker stop -t 300 $(docker ps --filter name="dagger-engine-*" -q)
         if: always()
 
+  license-check:
+    name: License check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Set up Nix
+        uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up magic Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@eeabdb06718ac63a7021c6132129679a8e22d0c7 # v3
+
+      - name: Cache license information
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        with:
+          path: .licensei.cache
+          key: licensei-v1-${{ github.ref_name }}-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            licensei-v1-${{ github.ref_name }}
+            licensei-v1-main
+            licensei-v1
+
+      - name: Prepare Nix shell
+        run: nix develop --impure .#ci
+
+      - name: Populate license cache
+        run: nix develop --impure .#ci -c licensei cache
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check licenses
+        run: nix develop --impure .#ci -c make license-check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   dev:
     name: Developer environment
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.direnv/
 /.env.local
 /.pre-commit-config.yaml
+/bin/
 /build/
 /config.yaml
 /tmp/

--- a/.licensei.toml
+++ b/.licensei.toml
@@ -1,25 +1,27 @@
 approved = [
-  "mit",
   "apache-2.0",
-  "bsd-3-clause",
+  "mit",
   "bsd-2-clause",
+  "bsd-3-clause",
   "mpl-2.0",
   "isc",
   "epl-2.0",
+  "richard-crowley",
 ]
 
 ignored = [
-  "github.com/invopop/yaml", # MIT
   "github.com/xeipuuv/gojsonpointer", # Apache 2.0
   "github.com/xeipuuv/gojsonreference", # Apache 2.0
   "github.com/xeipuuv/gojsonschema", # Apache 2.0
+  "github.com/couchbase/gocbcoreps", # Apache 2.0
+  "github.com/segmentio/asm", # MIT
+  "github.com/JohnCGriffin/overflow", # MIT
+  "github.com/invopop/yaml", # MIT
   "github.com/russross/blackfriday/v2", # 2-Clause BSD
   "github.com/gogo/protobuf", # 3-Clause BSD
-  "github.com/segmentio/asm", # MIT
-  
+
   "cuelang.org/go", # Apache 2.0
   "go.mongodb.org/mongo-driver", # Apache 2.0
-
 
   # Unsupported VCS
   "google.golang.org/protobuf", # 3-Clause BSD
@@ -27,6 +29,9 @@ ignored = [
   "modernc.org/mathutil", # 3-Clause BSD
   "modernc.org/memory", # 3-Clause BSD
   "modernc.org/sqlite", # 3-Clause BSD
+
+  # No license
+  "https://github.com/couchbase/goprotostellar"
 ]
 
 [header]

--- a/.licensei.toml
+++ b/.licensei.toml
@@ -1,6 +1,7 @@
 approved = [
   "apache-2.0",
   "mit",
+  "mit-0",
   "bsd-2-clause",
   "bsd-3-clause",
   "mpl-2.0",
@@ -14,11 +15,11 @@ ignored = [
   "github.com/xeipuuv/gojsonreference", # Apache 2.0
   "github.com/xeipuuv/gojsonschema", # Apache 2.0
   "github.com/couchbase/gocbcoreps", # Apache 2.0
-  "github.com/segmentio/asm", # MIT
   "github.com/JohnCGriffin/overflow", # MIT
   "github.com/invopop/yaml", # MIT
   "github.com/russross/blackfriday/v2", # 2-Clause BSD
   "github.com/gogo/protobuf", # 3-Clause BSD
+  "github.com/rcrowley/go-metrics", # Richard Crowley
 
   "cuelang.org/go", # Apache 2.0
   "go.mongodb.org/mongo-driver", # Apache 2.0
@@ -31,7 +32,7 @@ ignored = [
   "modernc.org/sqlite", # 3-Clause BSD
 
   # No license
-  "https://github.com/couchbase/goprotostellar"
+  "github.com/couchbase/goprotostellar",
 ]
 
 [header]

--- a/.licensei.toml
+++ b/.licensei.toml
@@ -3,6 +3,8 @@ approved = [
   "apache-2.0",
   "bsd-3-clause",
   "bsd-2-clause",
+  "mpl-2.0",
+  "isc",
   "epl-2.0",
 ]
 

--- a/.licensei.toml
+++ b/.licensei.toml
@@ -3,8 +3,28 @@ approved = [
   "apache-2.0",
   "bsd-3-clause",
   "bsd-2-clause",
-  "mpl-2.0",
-  "isc"
+  "epl-2.0",
+]
+
+ignored = [
+  "github.com/invopop/yaml", # MIT
+  "github.com/xeipuuv/gojsonpointer", # Apache 2.0
+  "github.com/xeipuuv/gojsonreference", # Apache 2.0
+  "github.com/xeipuuv/gojsonschema", # Apache 2.0
+  "github.com/russross/blackfriday/v2", # 2-Clause BSD
+  "github.com/gogo/protobuf", # 3-Clause BSD
+  "github.com/segmentio/asm", # MIT
+  
+  "cuelang.org/go", # Apache 2.0
+  "go.mongodb.org/mongo-driver", # Apache 2.0
+
+
+  # Unsupported VCS
+  "google.golang.org/protobuf", # 3-Clause BSD
+  "modernc.org/libc", # 3-Clause BSD
+  "modernc.org/mathutil", # 3-Clause BSD
+  "modernc.org/memory", # 3-Clause BSD
+  "modernc.org/sqlite", # 3-Clause BSD
 ]
 
 [header]

--- a/.licensei.toml
+++ b/.licensei.toml
@@ -1,0 +1,25 @@
+approved = [
+  "mit",
+  "apache-2.0",
+  "bsd-3-clause",
+  "bsd-2-clause",
+  "mpl-2.0",
+  "isc"
+]
+
+[header]
+ignorePaths = [".devenv", ".direnv", "vendor", "client", ".gen"]
+ignoreFiles = ["*.gen.go"]
+template = """// Copyright © :YEAR: Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License."""

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
+export PATH := $(abspath bin/):${PATH}
+
 .PHONY: up
 up: ## Start the dependencies via docker compose
 	$(call print-target)
@@ -32,28 +34,34 @@ config.yaml:
 server: ## Run sink-worker
 	@ if [ config.yaml -ot config.example.yaml ]; then diff -u config.yaml config.example.yaml || (echo "!!! The configuration example changed. Please update your config.yaml file accordingly (or at least touch it). !!!" && false); fi
 	$(call print-target)
-	air -c ./cmd/server/.air.toml
+	$(AIR_BIN) -c ./cmd/server/.air.toml
 
 .PHONY: sink-worker
 sink-worker: ## Run sink-worker
 	@ if [ config.yaml -ot config.example.yaml ]; then diff -u config.yaml config.example.yaml || (echo "!!! The configuration example changed. Please update your config.yaml file accordingly (or at least touch it). !!!" && false); fi
 	$(call print-target)
-	air -c ./cmd/sink-worker/.air.toml
+	$(AIR_BIN) -c ./cmd/sink-worker/.air.toml
 
 .PHONY: test
 test: ## Run tests
 	$(call print-target)
-	dagger call test
+	$(DAGGER_BIN) call test
 
 .PHONY: lint
 lint: ## Run linters
 	$(call print-target)
-	dagger call lint all
+	$(DAGGER_BIN) call lint all
+
+.PHONY: license-check
+license-check: ## Run license check
+	$(call print-target)
+	$(LICENSEI_BIN) check
+	$(LICENSEI_BIN) header
 
 .PHONY: fmt
 fmt: ## Format code
 	$(call print-target)
-	golangci-lint run --fix
+	$(GOLANGCI_LINT_BIN) run --fix
 
 .PHONY: mod
 mod: ## go mod tidy
@@ -63,7 +71,53 @@ mod: ## go mod tidy
 .PHONY: seed
 seed: ## Seed OpenMeter with test data
 	$(call print-target)
-	benthos -c etc/seed/seed.yaml
+	$(BENTHOS_BIN) -c etc/seed/seed.yaml
+	
+.PHONY: deps
+deps: bin/air bin/dagger bin/golangci-lint bin/licensei bin/benthos ## Install dependencies
+
+# Dependency versions
+AIR_VERSION = 1.51.0
+DAGGER_VERSION = 0.9.0
+GOLANGCI_VERSION = 1.53.1
+LICENSEI_VERSION = 0.8.0
+BENTHOS_VERSION = 4.24.0
+
+# Dependency binaries
+AIR_BIN := air
+DAGGER_BIN := dagger
+GOLANGCI_LINT_BIN := golangci-lint
+LICENSEI_BIN := licensei
+BENTHOS_BIN := benthos
+
+# If we have a "bin" dir, use those binaries instead
+ifneq ($(wildcard ./bin/.),)
+	AIR_BIN := bin/$(AIR_BIN)
+	DAGGER_BIN := bin/$(DAGGER_BIN)
+	GOLANGCI_LINT_BIN := bin/$(GOLANGCI_LINT_BIN)
+	LICENSEI_BIN := bin/$(LICENSEI_BIN)
+	BENTHOS_BIN := bin/$(BENTHOS_BIN)
+endif
+
+bin/air:
+	@mkdir -p bin
+	curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | bash -s -- v${AIR_VERSION}
+
+bin/dagger:
+	@mkdir -p bin
+	curl -sfL https://raw.githubusercontent.com/dagger/dagger/main/install.sh | bash -s -- v${DAGGER_VERSION}
+
+bin/golangci-lint:
+	@mkdir -p bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- v${GOLANGCI_VERSION}
+
+bin/licensei:
+	@mkdir -p bin
+	curl -sfL https://raw.githubusercontent.com/goph/licensei/master/install.sh | bash -s -- v${LICENSEI_VERSION}
+
+bin/benthos:
+	@mkdir -p bin
+	curl -Lsf https://sh.benthos.dev | bash -s -- ${BENTHOS_VERSION} ${PWD}/bin
 
 .PHONY: help
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build-server: ## Build server binary
 	go build -o build/server ./cmd/server
 
 .PHONY: build-sink-worker
-build-sink-worker: ## Build binary
+build-sink-worker: ## Build sink-worker binary
 	$(call print-target)
 	go build -o build/sink-worker ./cmd/sink-worker
 
@@ -31,7 +31,7 @@ config.yaml:
 	cp config.example.yaml config.yaml
 
 .PHONY: server
-server: ## Run sink-worker
+server: ## Run server
 	@ if [ config.yaml -ot config.example.yaml ]; then diff -u config.yaml config.example.yaml || (echo "!!! The configuration example changed. Please update your config.yaml file accordingly (or at least touch it). !!!" && false); fi
 	$(call print-target)
 	$(AIR_BIN) -c ./cmd/server/.air.toml

--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,11 @@ mod: ## go mod tidy
 seed: ## Seed OpenMeter with test data
 	$(call print-target)
 	$(BENTHOS_BIN) -c etc/seed/seed.yaml
-	
+
 .PHONY: deps
-deps: bin/air bin/dagger bin/golangci-lint bin/licensei bin/benthos ## Install dependencies
+deps: ## Install dependencies
+	$(call print-target)
+	$(MAKE) bin/air bin/dagger bin/golangci-lint bin/licensei bin/benthos
 
 # Dependency versions
 AIR_VERSION = 1.51.0

--- a/README.md
+++ b/README.md
@@ -101,7 +101,11 @@ For other shells, see [https://direnv.net/docs/hook.html](https://direnv.net/doc
 Nix may stop working after a MacOS upgrade. If it does, follow [these instructions](https://github.com/NixOS/nix/issues/3616#issuecomment-662858874).
 
 <hr>
-</details>
+</details><br>
+
+_Alternatively, install [Go](https://go.dev/dl/) on your computer then run `make deps` to install the rest of the dependencies._
+
+Make sure Docker is installed with Compose and Buildx.
 
 Run the dependencies:
 
@@ -109,10 +113,17 @@ Run the dependencies:
 make up
 ```
 
-Run OpenMeter:
-
+Run project components:
 ```sh
-make run
+make sink-worker
+make server
+```
+
+Build binary:
+
+```shell
+make build-sink-worker # Builds sink-worker binary
+make build-server # Builds server binary
 ```
 
 Run tests:
@@ -125,6 +136,22 @@ Run linters:
 
 ```sh
 make lint
+```
+
+Some linter violations can automatically be fixed:
+
+```shell
+make fmt
+```
+Generate go code:
+```shell
+make generate
+```
+
+Once you are done, you can tear down project dependencies:
+
+```shell
+make down
 ```
 
 ## Roadmap

--- a/api/api.go
+++ b/api/api.go
@@ -1,2 +1,16 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:generate go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen --config=codegen.yaml ./openapi.yaml
 package api

--- a/api/client/go/client.go
+++ b/api/client/go/client.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:generate go run github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen --config=codegen.yaml ../../openapi.yaml
 package openmeter
 

--- a/api/client/go/error.go
+++ b/api/client/go/error.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package openmeter
 
 // ErrResponse renderer type for handling all sorts of errors.

--- a/ci/build.go
+++ b/ci/build.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/ci/e2e.go
+++ b/ci/e2e.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/ci/lint.go
+++ b/ci/lint.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/ci/main.go
+++ b/ci/main.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/ci/release.go
+++ b/ci/release.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/ci/utils.go
+++ b/ci/utils.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/benthos-collector/main.go
+++ b/cmd/benthos-collector/main.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/server/version.go
+++ b/cmd/server/version.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import "runtime/debug"

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/cmd/sink-worker/version.go
+++ b/cmd/sink-worker/version.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import "runtime/debug"

--- a/collector/benthos/input/kubernetes.go
+++ b/collector/benthos/input/kubernetes.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package input
 
 import (

--- a/collector/benthos/input/otel_log.go
+++ b/collector/benthos/input/otel_log.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package input
 
 import (

--- a/collector/benthos/input/schedule.go
+++ b/collector/benthos/input/schedule.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package input
 
 import (

--- a/collector/benthos/internal/message/batch.go
+++ b/collector/benthos/internal/message/batch.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package message
 
 import "github.com/benthosdev/benthos/v4/public/service"

--- a/collector/benthos/internal/message/transaction.go
+++ b/collector/benthos/internal/message/transaction.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package message
 
 import "context"

--- a/collector/benthos/internal/shutdown/signaler.go
+++ b/collector/benthos/internal/shutdown/signaler.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package shutdown
 
 import (

--- a/collector/benthos/output/openmeter.go
+++ b/collector/benthos/output/openmeter.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package output
 
 import (

--- a/collector/benthos/output/otel_log.go
+++ b/collector/benthos/output/otel_log.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package output
 
 import (

--- a/config/aggregation.go
+++ b/config/aggregation.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package config loads application configuration.
 package config
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/config/dedupe.go
+++ b/config/dedupe.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/config/namespace.go
+++ b/config/namespace.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/config/portal.go
+++ b/config/portal.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/config/sink.go
+++ b/config/sink.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/config/telemetry.go
+++ b/config/telemetry.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/config/viper.go
+++ b/config/viper.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package config
 
 import (

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e
 
 import (

--- a/examples/export-stripe-go/main.go
+++ b/examples/export-stripe-go/main.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/export-stripe-go/report.go
+++ b/examples/export-stripe-go/report.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/examples/export-stripe-go/setup.go
+++ b/examples/export-stripe-go/setup.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/internal/dedupe/dedupe.go
+++ b/internal/dedupe/dedupe.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package dedupe implements in-process event deduplication.
 package dedupe
 

--- a/internal/dedupe/memorydedupe/memorydedupe.go
+++ b/internal/dedupe/memorydedupe/memorydedupe.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package memorydedupe implements in-memory event deduplication.
 package memorydedupe
 

--- a/internal/dedupe/memorydedupe/memorydedupe_test.go
+++ b/internal/dedupe/memorydedupe/memorydedupe_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package memorydedupe_test
 
 import (

--- a/internal/dedupe/redisdedupe/redisdedupe.go
+++ b/internal/dedupe/redisdedupe/redisdedupe.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package redisdedupe implements event deduplication using Redis.
 package redisdedupe
 

--- a/internal/ingest/dedupe.go
+++ b/internal/ingest/dedupe.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ingest
 
 import (

--- a/internal/ingest/dedupe_test.go
+++ b/internal/ingest/dedupe_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ingest_test
 
 import (

--- a/internal/ingest/httpingest/httpingest.go
+++ b/internal/ingest/httpingest/httpingest.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package httpingest
 
 import (

--- a/internal/ingest/httpingest/httpingest_test.go
+++ b/internal/ingest/httpingest/httpingest_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package httpingest
 
 import (

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package ingest implements event ingestion.
 package ingest
 

--- a/internal/ingest/inmemory.go
+++ b/internal/ingest/inmemory.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ingest
 
 import (

--- a/internal/ingest/inmemory_test.go
+++ b/internal/ingest/inmemory_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ingest_test
 
 import (

--- a/internal/ingest/kafkaingest/collector.go
+++ b/internal/ingest/kafkaingest/collector.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kafkaingest
 
 import (

--- a/internal/ingest/kafkaingest/namespace.go
+++ b/internal/ingest/kafkaingest/namespace.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kafkaingest
 
 import (

--- a/internal/ingest/kafkaingest/serializer/json.go
+++ b/internal/ingest/kafkaingest/serializer/json.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package serializer
 
 import (

--- a/internal/ingest/kafkaingest/serializer/serializer.go
+++ b/internal/ingest/kafkaingest/serializer/serializer.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package serializer
 
 import (

--- a/internal/meter/inmemory.go
+++ b/internal/meter/inmemory.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package meter
 
 import (

--- a/internal/meter/meter.go
+++ b/internal/meter/meter.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package meter
 
 import (

--- a/internal/namespace/namespace.go
+++ b/internal/namespace/namespace.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package namespace adds a concept of tenancy to OpenMeter allowing to segment clients.
 package namespace
 

--- a/internal/namespace/namespace_test.go
+++ b/internal/namespace/namespace_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package namespace
 
 import (

--- a/internal/server/authenticator/authenticator.go
+++ b/internal/server/authenticator/authenticator.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package authenticator
 
 import (

--- a/internal/server/authenticator/portal.go
+++ b/internal/server/authenticator/portal.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package authenticator
 
 import (

--- a/internal/server/cors.go
+++ b/internal/server/cors.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/internal/server/logger.go
+++ b/internal/server/logger.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/internal/server/router/event.go
+++ b/internal/server/router/event.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package router
 
 import (

--- a/internal/server/router/meter.go
+++ b/internal/server/router/meter.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package router
 
 import (

--- a/internal/server/router/meter_query.go
+++ b/internal/server/router/meter_query.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package router
 
 import (

--- a/internal/server/router/meter_subject.go
+++ b/internal/server/router/meter_subject.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package router
 
 import (

--- a/internal/server/router/portal.go
+++ b/internal/server/router/portal.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package router
 
 import (

--- a/internal/server/router/router.go
+++ b/internal/server/router/router.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package router
 
 import (

--- a/internal/server/router/subject.go
+++ b/internal/server/router/subject.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package router
 
 import (

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/internal/sink/buffer.go
+++ b/internal/sink/buffer.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sink
 
 import (

--- a/internal/sink/buffer_test.go
+++ b/internal/sink/buffer_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sink_test
 
 import (

--- a/internal/sink/model.go
+++ b/internal/sink/model.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sink
 
 type ProcessingControl int32

--- a/internal/sink/namespaces.go
+++ b/internal/sink/namespaces.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sink
 
 import (

--- a/internal/sink/namespaces_test.go
+++ b/internal/sink/namespaces_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sink_test
 
 import (

--- a/internal/sink/partition.go
+++ b/internal/sink/partition.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sink
 
 import (

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sink
 
 import (

--- a/internal/sink/storage.go
+++ b/internal/sink/storage.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sink
 
 import (

--- a/internal/sink/storage_test.go
+++ b/internal/sink/storage_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package sink_test
 
 import (

--- a/internal/streaming/clickhouse_connector/connector.go
+++ b/internal/streaming/clickhouse_connector/connector.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package clickhouse_connector
 
 import (

--- a/internal/streaming/clickhouse_connector/model.go
+++ b/internal/streaming/clickhouse_connector/model.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package clickhouse_connector
 
 import "github.com/openmeterio/openmeter/pkg/models"

--- a/internal/streaming/clickhouse_connector/query.go
+++ b/internal/streaming/clickhouse_connector/query.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package clickhouse_connector
 
 import (

--- a/internal/streaming/clickhouse_connector/query_test.go
+++ b/internal/streaming/clickhouse_connector/query_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package clickhouse_connector
 
 import (

--- a/internal/streaming/connector.go
+++ b/internal/streaming/connector.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package streaming
 
 import (

--- a/internal/streaming/query_params.go
+++ b/internal/streaming/query_params.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package streaming
 
 import (

--- a/internal/streaming/query_params_test.go
+++ b/internal/streaming/query_params_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package streaming
 
 import (

--- a/openmeter/dedupe/memorydedupe/memorydedupe.go
+++ b/openmeter/dedupe/memorydedupe/memorydedupe.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package memorydedupe implements in-memory event deduplication.
 package memorydedupe
 

--- a/openmeter/dedupe/redisdedupe/redisdedupe.go
+++ b/openmeter/dedupe/redisdedupe/redisdedupe.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package redisdedupe implements event deduplication using Redis.
 package redisdedupe
 

--- a/openmeter/ingest/dedupe.go
+++ b/openmeter/ingest/dedupe.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ingest
 
 import (

--- a/openmeter/ingest/httpingest/httpingest.go
+++ b/openmeter/ingest/httpingest/httpingest.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package httpingest
 
 import (

--- a/openmeter/ingest/ingest.go
+++ b/openmeter/ingest/ingest.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package ingest implements event ingestion.
 package ingest
 

--- a/openmeter/ingest/inmemory.go
+++ b/openmeter/ingest/inmemory.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ingest
 
 import (

--- a/openmeter/ingest/kafkaingest/collector.go
+++ b/openmeter/ingest/kafkaingest/collector.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kafkaingest
 
 import (

--- a/openmeter/ingest/kafkaingest/namespace.go
+++ b/openmeter/ingest/kafkaingest/namespace.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kafkaingest
 
 import (

--- a/openmeter/ingest/kafkaingest/serializer/json.go
+++ b/openmeter/ingest/kafkaingest/serializer/json.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package serializer
 
 import (

--- a/openmeter/ingest/kafkaingest/serializer/serializer.go
+++ b/openmeter/ingest/kafkaingest/serializer/serializer.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package serializer
 
 import (

--- a/openmeter/meter/inmemory.go
+++ b/openmeter/meter/inmemory.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package meter
 
 import (

--- a/openmeter/meter/meter.go
+++ b/openmeter/meter/meter.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package meter
 
 import (

--- a/openmeter/namespace/namespace.go
+++ b/openmeter/namespace/namespace.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package namespace adds a concept of tenancy to OpenMeter allowing to segment clients.
 package namespace
 

--- a/openmeter/openmeter.go
+++ b/openmeter/openmeter.go
@@ -1,2 +1,16 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package openmeter is an experimental package to expose the core of OpenMeter as a library.
 package openmeter

--- a/openmeter/server/router/router.go
+++ b/openmeter/server/router/router.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package router
 
 import (

--- a/openmeter/server/server.go
+++ b/openmeter/server/server.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package that implements event sink logic.
 package sink
 

--- a/openmeter/streaming/clickhouse_connector/connector.go
+++ b/openmeter/streaming/clickhouse_connector/connector.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package clickhouse_connector
 
 import (

--- a/openmeter/streaming/clickhouse_connector/model.go
+++ b/openmeter/streaming/clickhouse_connector/model.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package clickhouse_connector
 
 import (

--- a/openmeter/streaming/connector.go
+++ b/openmeter/streaming/connector.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package streaming
 
 import (

--- a/pkg/contextx/attr.go
+++ b/pkg/contextx/attr.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package contextx
 
 import (

--- a/pkg/contextx/log.go
+++ b/pkg/contextx/log.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package contextx
 
 import (

--- a/pkg/errorsx/handler.go
+++ b/pkg/errorsx/handler.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package errorsx
 
 import (

--- a/pkg/gosundheit/logger.go
+++ b/pkg/gosundheit/logger.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gosundheit
 
 import (

--- a/pkg/kafka/kafka.go
+++ b/pkg/kafka/kafka.go
@@ -1,2 +1,16 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package kafka implements tools to work with kafka Producers and Consumers.
 package kafka

--- a/pkg/kafka/log.go
+++ b/pkg/kafka/log.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kafka
 
 import (

--- a/pkg/models/error.go
+++ b/pkg/models/error.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import "fmt"

--- a/pkg/models/meter.go
+++ b/pkg/models/meter.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import (

--- a/pkg/models/meter_test.go
+++ b/pkg/models/meter_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import (

--- a/pkg/models/problem.go
+++ b/pkg/models/problem.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package models
 
 import (

--- a/pkg/slicesx/map.go
+++ b/pkg/slicesx/map.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package slicesx
 
 // Map maps elements of a slice from T to M, returning a new slice.

--- a/pkg/slicesx/map_test.go
+++ b/pkg/slicesx/map_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package slicesx
 
 import (

--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,17 @@
+// Copyright © 2024 Tailfin Cloud Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //go:build tools
 // +build tools
 


### PR DESCRIPTION
## Overview

- Added `makefile` target for project dependencies.
- Licensei was only added as a nixpkg. 

Fixes #22

## Checklist

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I have made corresponding changes to the documentation
- [ X ] My changes generate no new warnings
- [ X ] I have added tests that prove my fix is effective or that my feature works
- [ X ] New and existing unit tests pass locally with my changes
